### PR TITLE
Implement non-blocking manual PWM ramp

### DIFF
--- a/include/edugrid_pwm_control.h
+++ b/include/edugrid_pwm_control.h
@@ -32,9 +32,10 @@ class edugrid_pwm_control
 public:
     /* Percent-based API (0..100 %) */
     static void     setPWM(uint8_t pwm_in, bool auto_mode = false);
-    static void     setPWM_ramped(uint8_t target, uint8_t step = 2, uint16_t us_between_steps = 200);
     static uint8_t  getPWM();                  // 0..100 [%]
     static float    getPWM_normalized();       // 0.0..1.0
+    static void     requestManualTarget(uint8_t target);
+    static void     serviceManualRamp();
 
     /* Frequency API */
     static void     setFrequency(float freq_hz);   // reconfigure LEDC timer
@@ -62,6 +63,8 @@ private:
     static int      power_converter_pin;      // GPIO
     static uint8_t  pwm_abs_min;              // [%]
     static uint8_t  pwm_abs_max;              // [%]
+    static uint8_t  manual_target;            // [%]
+    static uint32_t manual_last_step_ms;      // [ms]
 
     /* LEDC config */
     static const int _ledc_channel;           // LEDC channel used

--- a/include/edugrid_states.h
+++ b/include/edugrid_states.h
@@ -78,7 +78,7 @@
  * Manual mode slew limiting (UI slider)
  ************************************************************************/
 #define MANUAL_SLEW_STEP_PCT      (1)        /* 1% per ramp step */
-#define MANUAL_SLEW_US_BETWEEN    (40000)    /* 40 ms between steps */
+#define MANUAL_SLEW_INTERVAL_MS   (40)       /* 40 ms between steps */
 
 /*************************************************************************
  * Filesystem states (unchanged)

--- a/src/edugrid_webserver.cpp
+++ b/src/edugrid_webserver.cpp
@@ -188,10 +188,8 @@ void edugrid_webserver::initWiFi(void)
       } else if (_id.equals(WEBSERVER_ID_PWM_DECREMENT)) {
         edugrid_pwm_control::pwmIncrementDecrement(-5);
       } else if (_id.equals(WEBSERVER_ID_PWM_SLIDER)) {
-          edugrid_pwm_control::setPWM_ramped(
-            (uint8_t)_state.toInt(),
-            MANUAL_SLEW_STEP_PCT,
-            MANUAL_SLEW_US_BETWEEN);
+          edugrid_pwm_control::requestManualTarget(
+            (uint8_t)_state.toInt());
       } else if (_id.equals(WEBSERVER_ID_MODE_LABEL)) {
         // Client must send the desired state: "AUTO" or "MANUAL".
         // We do not toggle here. We never enter IV_SWEEP from MODE clicks.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,7 @@ void coreThree(void *pvParameters)
 
     /* 2) Keep duty within safe/allowed borders (this is good practice) */
     edugrid_pwm_control::checkAndSetPwmBorders();
+    edugrid_pwm_control::serviceManualRamp();
 
     /* 3) Execute the logic for the current operating mode */
     switch (edugrid_mpp_algorithm::get_mode_state())


### PR DESCRIPTION
## Summary
- convert the manual slew interval constant to milliseconds
- add a non-blocking manual PWM ramp with cached target and timing
- service the ramp from the control loop and update the web UI to request new targets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d660a743588325a217e3feb6d49af0