### PR TITLE
Refine runtime constants and streamline logging

### DIFF
--- a/include/edugrid_filesystem.h
+++ b/include/edugrid_filesystem.h
@@ -13,7 +13,6 @@
 #include <Arduino.h>
 #include <LittleFS.h>
 #include <edugrid_states.h>
-#include <edugrid_webserver.h>
 
 /*************************************************************************
  * Define

--- a/include/edugrid_logging.h
+++ b/include/edugrid_logging.h
@@ -35,12 +35,11 @@ public:
     static void activateLogging();
     static void deactivateLogging();
     static void toggleLogging();
-    static void appendLog(String field0, String field1, String field2, String field3);
+    static void appendLog(float vin, float vout, float iin, float iout);
 
 private:
     static bool log_active;
     static bool safe_request;
-    static String log_line;
     static String log_message_buffer;
     static uint8_t log_message_counter;
     static unsigned long all_messages;

--- a/include/edugrid_states.h
+++ b/include/edugrid_states.h
@@ -13,6 +13,15 @@
 #define OTA_UPDATES_ENABLE
 
 /*************************************************************************
+ * Core runtime cadence & serial link
+ ************************************************************************/
+#define EDUGRID_SERIAL_BAUD          (115200UL)
+#define TASK_LOOP_INTERVAL_MS        (1000UL)   /* loop() logging tick */
+#define TASK_WEBSOCKET_INTERVAL_MS   (100UL)    /* WebSocket pump task */
+#define TASK_CONTROL_INTERVAL_MS     (20UL)     /* MPPT + sensing task */
+#define WS_PUSH_INTERVAL_MS          (100UL)    /* WebSocket broadcast cadence */
+
+/*************************************************************************
  * INA228 configuration (shared by AUTO & IV)
  ************************************************************************/
 #define INA_PV_ADDR               (0x40)
@@ -21,6 +30,8 @@
 #define INA_MAX_CURRENT_A         (16.0f)   /* set to your HW limit */
 
 #define PV_PRESENT_V              (1.0f)
+#define ZERO_V_CLAMP              (0.02f)
+#define ZERO_I_CLAMP              (0.01f)
 
 #define INA_AVG_SAMPLES           (128UL)    /* AVG = 128 */
 #define INA_CONV_US               (1052UL)   /* 1.052 ms per shunt/bus conversion */
@@ -65,13 +76,13 @@
 
 /* Compile-time sanity checks */
 #if (IV_SWEEP_D_MIN_PCT < PWM_MIN_DUTY_PCT) || (IV_SWEEP_D_MAX_PCT > PWM_MAX_DUTY_PCT)
-# error "IV sweep bounds must lie within PWM_MIN_DUTY_PCT..PWM_MAX_DUTY_PCT"
+#error "IV sweep bounds must lie within PWM_MIN_DUTY_PCT..PWM_MAX_DUTY_PCT"
 #endif
 #if (IV_SWEEP_D_MIN_PCT > IV_SWEEP_D_MAX_PCT)
-# error "IV_SWEEP_D_MIN_PCT must be <= IV_SWEEP_D_MAX_PCT"
+#error "IV_SWEEP_D_MIN_PCT must be <= IV_SWEEP_D_MAX_PCT"
 #endif
 #if ((IV_SWEEP_D_MAX_PCT - IV_SWEEP_D_MIN_PCT) % IV_SWEEP_STEP_PCT) != 0
-# error "Sweep range must be divisible by IV_SWEEP_STEP_PCT"
+#error "Sweep range must be divisible by IV_SWEEP_STEP_PCT"
 #endif
 
 /*************************************************************************

--- a/include/edugrid_webserver.h
+++ b/include/edugrid_webserver.h
@@ -60,14 +60,9 @@ private:
     static void handleUpload(AsyncWebServerRequest* request, String filename,
                          size_t index, uint8_t* data, size_t len, bool final);
     static String listFiles(bool ishtml);
-    static void setWiFiCredentials(String ssid, String pw);
-
     static String _id;
     static String _state;
-    static String _state2;
     static String JSON_str;
-    static String wifi_name;
-    static String wifi_password;
 };
 
 #endif /* EDUGRID_WEBSERVER_H_ */

--- a/src/edugrid_logging.cpp
+++ b/src/edugrid_logging.cpp
@@ -18,7 +18,6 @@
  ************************************************************************/
 bool edugrid_logging::log_active = false;
 bool edugrid_logging::safe_request = false;
-String edugrid_logging::log_line = "";
 String edugrid_logging::log_message_buffer = "";
 uint8_t edugrid_logging::log_message_counter = 0;
 unsigned long edugrid_logging::log_start_time = 0;
@@ -49,6 +48,8 @@ void edugrid_logging::activateLogging()
 {
   log_active = true;
   log_start_time = millis();
+  log_message_buffer = "";
+  log_message_buffer.reserve(EDUGRID_LOGGING_MAX_MESSAGES_IN_BUFFER * 48);
   /* Clear log file content */
   edugrid_filesystem::writeContent_str(edugrid_filesystem::config_log_name, "");
   Serial.print("| OK | Logging  ");
@@ -83,25 +84,28 @@ void edugrid_logging::toggleLogging()
   }
 }
 
-void edugrid_logging::appendLog(String field0, String field1, String field2, String field3)
+void edugrid_logging::appendLog(float vin, float vout, float iin, float iout)
 {
   /* Log only, if activated */
   if (getLogState() == EDUGRID_LOGGING_ACTIVE)
   {
     log_message_counter += 1;
     all_messages += 1;
-    log_line =
-        (String)all_messages + EDUGRID_LOGGING_CSV_DELIMITER +
-        field0 + EDUGRID_LOGGING_CSV_DELIMITER +
-        field1 + EDUGRID_LOGGING_CSV_DELIMITER +
-        field2 + EDUGRID_LOGGING_CSV_DELIMITER +
-        field3 + "\n";
+    String line;
+    line.reserve(64);
+    line += all_messages;
+    line += EDUGRID_LOGGING_CSV_DELIMITER;
+    line += String(vin, 3);
+    line += EDUGRID_LOGGING_CSV_DELIMITER;
+    line += String(vout, 3);
+    line += EDUGRID_LOGGING_CSV_DELIMITER;
+    line += String(iin, 3);
+    line += EDUGRID_LOGGING_CSV_DELIMITER;
+    line += String(iout, 3);
+    line += '\n';
 
     /* add new log line to buffer String */
-    log_message_buffer += log_line;
-
-    /* Clear log_line */
-    log_line = "";
+    log_message_buffer += line;
 
     /* Check for logging timeout*/
     if ((millis() - log_start_time) >= EDUGRID_LOGGING_MAX_TIME_MS)

--- a/src/edugrid_measurement.cpp
+++ b/src/edugrid_measurement.cpp
@@ -8,17 +8,6 @@
 #include <math.h>
 #include "edugrid_mpp_algorithm.h" 
 
-/* ===== Tunables (fallbacks if not set elsewhere) ===== */
-#ifndef PV_PRESENT_V
-#define PV_PRESENT_V (1.0f)   // treat system as "off" when raw PV < 1.0 V
-#endif
-#ifndef ZERO_V_CLAMP
-#define ZERO_V_CLAMP (0.02f)  // 20 mV deadband
-#endif
-#ifndef ZERO_I_CLAMP
-#define ZERO_I_CLAMP (0.01f)  // 10 mA deadband
-#endif
-
 /* ===== Static storage ===== */
 Adafruit_INA228 edugrid_measurement::_ina_pv;
 Adafruit_INA228 edugrid_measurement::_ina_load;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,11 +22,6 @@
 /************************************************************************
  * Defines
  ************************************************************************/
-#define BAUD_RATE (115200)
-#define CYCLE_TIME_TASK_LOOP_MS      (1000)   // [ms]  Display & Logging
-#define CYCLE_TIME_TASK_WEBSOCKET_MS (100)    // [ms]  WebSocket tick
-#define CYCLE_TIME_TASK_CONTROL_MS   (20)     // [ms]  How often the control task runs (50 Hz)
-
 /************************************************************************
  * RTOS Task Handles
  ************************************************************************/
@@ -42,7 +37,7 @@ void coreTwo(void *pvParameters)
   for (;;)
   {
     edugrid_webserver::webSocketLoop();
-    vTaskDelay(pdMS_TO_TICKS(CYCLE_TIME_TASK_WEBSOCKET_MS));
+    vTaskDelay(pdMS_TO_TICKS(TASK_WEBSOCKET_INTERVAL_MS));
   }
 }
 
@@ -88,7 +83,7 @@ void coreThree(void *pvParameters)
     /* 4) Loop timing */
     // Use a single, consistent delay for the whole task.
     // This makes the loop predictable and responsive.
-    vTaskDelay(pdMS_TO_TICKS(CYCLE_TIME_TASK_CONTROL_MS));
+    vTaskDelay(pdMS_TO_TICKS(TASK_CONTROL_INTERVAL_MS));
   }
 }
 
@@ -99,7 +94,7 @@ void coreThree(void *pvParameters)
 void setup()
 {
   /* Serial — start this FIRST so we see all boot logs */
-  Serial.begin(BAUD_RATE);
+  Serial.begin(EDUGRID_SERIAL_BAUD);
   delay(200);
   Serial.println();
   Serial.println(F("[BOOT] EduGrid starting..."));
@@ -167,10 +162,10 @@ void setup()
 void loop()
 {
   edugrid_logging::appendLog(
-      String(edugrid_measurement::V_in),
-      String(edugrid_measurement::V_out),
-      String(edugrid_measurement::I_in),
-      String(edugrid_measurement::I_out));
+      edugrid_measurement::V_in,
+      edugrid_measurement::V_out,
+      edugrid_measurement::I_in,
+      edugrid_measurement::I_out);
 
-  delay(CYCLE_TIME_TASK_LOOP_MS);
+  delay(TASK_LOOP_INTERVAL_MS);
 }


### PR DESCRIPTION
## Summary
- centralize task timing, INA deadband values, and WebSocket cadence in `edugrid_states.h`
- streamline logging by formatting inside `appendLog` and preallocating its buffer
- drop unused webserver state and reuse a static JSON document for IV sweep responses

## Testing
- `pio run` *(fails: PlatformIO CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d667f81af88325a947662e5971c790