### PR TITLE
Leave IV sweep in manual mode at max duty

### DIFF
--- a/data/www/script.js
+++ b/data/www/script.js
@@ -76,15 +76,26 @@ function connectWS() {
       const fmtPct = x => Number.isFinite(x) ? x.toFixed(1) + " %" : "--";
 
       // ---------- PWM / Frequency ----------
-      if (el("pwm_label")) setText("pwm_label", j.pwm ?? "--");
-      if (el("freq_label")) setText("freq_label", j.freq ?? "--");
+      const pwmValue = Number(j.pwm);
+      if (el("pwm_label")) {
+        setText("pwm_label", Number.isFinite(pwmValue) ? pwmValue.toFixed(0) + " %" : "--");
+      }
+
+      const freqHz  = Number(j.freq_hz);
+      if (el("freq_label")) {
+        if (Number.isFinite(freqHz)) {
+          const freqDisplay = freqHz >= 100 ? freqHz.toFixed(0) : freqHz.toFixed(1);
+          setText("freq_label", freqDisplay + " Hz");
+        } else {
+          setText("freq_label", "--");
+        }
+      }
 
       const slider = el("4");
-      const pwmRaw = Number(j.pwm_raw);
       if (slider) {
         if (j.pwm_min !== undefined) slider.min = j.pwm_min;
         if (j.pwm_max !== undefined) slider.max = j.pwm_max;
-        if (!isDraggingSlider && Number.isFinite(pwmRaw)) slider.value = pwmRaw;
+        if (!isDraggingSlider && Number.isFinite(pwmValue)) slider.value = pwmValue;
       }
 
       // ---------- MODE label ----------

--- a/include/edugrid_mpp_algorithm.h
+++ b/include/edugrid_mpp_algorithm.h
@@ -81,6 +81,7 @@ private:
     static uint16_t         _iv_idx;        // current point index
     static uint16_t         _iv_count;      // number of points captured
     static uint32_t         _iv_last_ms;    // timing gate (~ INA_STEP_PERIOD_MS)
+    static bool             _iv_finalize_applied;
 
     /* ---------- IV sweep buffers (Vin, Iin) ---------- */
     static float            _iv_v[IV_SWEEP_POINTS];

--- a/include/edugrid_webserver.h
+++ b/include/edugrid_webserver.h
@@ -53,7 +53,6 @@ public:
     static void initWiFi(void);
     static void webSocketLoop(void);
     static String humanReadableSize(const size_t bytes);
-    static StaticJsonDocument<1024> doc;
 
 private:
     static String processor(const String &var);
@@ -62,7 +61,6 @@ private:
     static String listFiles(bool ishtml);
     static String _id;
     static String _state;
-    static String JSON_str;
 };
 
 #endif /* EDUGRID_WEBSERVER_H_ */

--- a/src/edugrid_mpp_algorithm.cpp
+++ b/src/edugrid_mpp_algorithm.cpp
@@ -26,6 +26,7 @@ edugrid_mpp_algorithm::IVPhase edugrid_mpp_algorithm::_iv_phase = IVPhase::Idle;
 uint16_t edugrid_mpp_algorithm::_iv_idx   = 0;
 uint16_t edugrid_mpp_algorithm::_iv_count = 0;
 uint32_t edugrid_mpp_algorithm::_iv_last_ms = 0;
+bool edugrid_mpp_algorithm::_iv_finalize_applied = false;
 
 /* IV buffers */
 float edugrid_mpp_algorithm::_iv_v[IV_SWEEP_POINTS] = {0};
@@ -87,6 +88,8 @@ int edugrid_mpp_algorithm::find_mpp(void)
 
 void edugrid_mpp_algorithm::request_iv_sweep()
 {
+  _iv_finalize_applied = false;
+  set_mode_state(IV_SWEEP);
   _iv_phase    = IVPhase::Arm;
   _iv_idx    = 0;
   _iv_count    = 0;
@@ -132,6 +135,12 @@ void edugrid_mpp_algorithm::iv_sweep_step(void)
 
     case IVPhase::Done:
     default:
+      if (!_iv_finalize_applied) {
+        _iv_finalize_applied = true;
+        edugrid_pwm_control::setPWM(PWM_MAX_DUTY_PCT);
+        edugrid_pwm_control::requestManualTarget(PWM_MAX_DUTY_PCT);
+        set_mode_state(MANUALLY);
+      }
       break;  // no-op; caller can query iv_sweep_done()
   }
 }


### PR DESCRIPTION
## Summary
- drop the IV sweep bookkeeping that restored the prior operating mode and duty
- finish the sweep by forcing manual mode with the 95% duty cap so the converter stays at full output

## Testing
- ⚠️ `pio run` *(fails: PlatformIO CLI is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d68e998c14832594fc15ff9d7aea50